### PR TITLE
Revert "NSObject conforms to StoryboardInstantiatable"

### DIFF
--- a/DipUI/DipUITests/DipUITests.swift
+++ b/DipUI/DipUITests/DipUITests.swift
@@ -59,8 +59,8 @@ import XCTest
 #endif
 
 
-class DipViewController: ViewController {}
-class NilTagViewController: ViewController {}
+class DipViewController: ViewController, StoryboardInstantiatable {}
+class NilTagViewController: ViewController, StoryboardInstantiatable {}
 
 class DipUITests: XCTestCase {
   
@@ -200,7 +200,6 @@ class ViewControllerImp: SomeScreen, SomeServiceDelegate, OtherServiceDelegate {
 extension DipUITests {
   
   func testThatItDoesNotCreateNewInstanceWhenResolvingDependenciesOfExternalInstance() {
-    Dip.logLevel = .Verbose
     let container = DependencyContainer()
     
     //given
@@ -212,7 +211,7 @@ extension DipUITests {
     
     //when
     let screen = ViewControllerImp()
-    try! container.resolveDependencies(of: screen as SomeScreen, type: SomeScreen.self)
+    try! container.resolveDependencies(of: screen as SomeScreen)
     
     //then
     XCTAssertFalse(factoryCalled, "Container should not create new instance when resolving dependencies of external instance.")


### PR DESCRIPTION
Reverts AliSoftware/Dip-UI#22

Unfortunately it looks like with such implementation there is no way to override method of StoryboardInstantiatable to resolve object not as a its concrete type. At runtime default implementation from extension is always called instead of its custom implementation in concrete type.
